### PR TITLE
test: 未登録パスワード管理APIのテスト整備 (#82)

### DIFF
--- a/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllController.php
+++ b/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\UnregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\UnregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class UnregistedPasswordDeleteAllController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        UnregistedPassword::query()->delete();
+        return ApiResponseFormatter::ok();
+    }
+}

--- a/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexController.php
+++ b/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\UnregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\UnregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class UnregistedPasswordIndexController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $unregistedPasswords = UnregistedPassword::with(['application', 'account'])
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $response = $unregistedPasswords->map(function ($unregistedPassword) {
+            return [
+                'uuid' => $unregistedPassword->uuid,
+                'password' => $unregistedPassword->password,
+                'application' => $unregistedPassword->application ? [
+                    'id' => $unregistedPassword->application->id,
+                    'name' => $unregistedPassword->application->name,
+                ] : null,
+                'account' => $unregistedPassword->account ? [
+                    'id' => $unregistedPassword->account->id,
+                    'name' => $unregistedPassword->account->name,
+                ] : null,
+                'created_at' => optional($unregistedPassword->created_at)->toISOString(),
+            ];
+        })->toArray();
+
+        return ApiResponseFormatter::ok($response);
+    }
+}

--- a/app/Http/Controllers/UnregistedPassword/UnregistedPasswordShowController.php
+++ b/app/Http/Controllers/UnregistedPassword/UnregistedPasswordShowController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\UnregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\UnregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class UnregistedPasswordShowController extends Controller
+{
+    public function __invoke(UnregistedPassword $unregistedPassword): JsonResponse
+    {
+        $unregistedPassword->load(['application', 'account']);
+
+        return ApiResponseFormatter::ok([
+            'uuid' => $unregistedPassword->uuid,
+            'password' => $unregistedPassword->password,
+            'application' => $unregistedPassword->application ? [
+                'id' => $unregistedPassword->application->id,
+                'name' => $unregistedPassword->application->name,
+            ] : null,
+            'account' => $unregistedPassword->account ? [
+                'id' => $unregistedPassword->account->id,
+                'name' => $unregistedPassword->account->name,
+            ] : null,
+            'created_at' => optional($unregistedPassword->created_at)->toISOString(),
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ Route::prefix('v2')->group(function () {
     require base_path('routes/api/v2/application.php');
     require base_path('routes/api/v2/account.php');
     require base_path('routes/api/v2/menu.php');
+    require base_path('routes/api/v2/unregisted_password.php');
     Route::get('check', function () {
         return response()->json(['status' => 'ok']);
     });

--- a/routes/api/v2/unregisted_password.php
+++ b/routes/api/v2/unregisted_password.php
@@ -1,0 +1,18 @@
+<?php
+
+// 未登録パスワード管理
+
+use App\Http\Controllers\UnregistedPassword\UnregistedPasswordDeleteAllController;
+use App\Http\Controllers\UnregistedPassword\UnregistedPasswordIndexController;
+use App\Http\Controllers\UnregistedPassword\UnregistedPasswordShowController;
+
+Route::prefix('/unregisted-passwords')->group(function () {
+    Route::middleware('auth:api')->group(function () {
+        Route::get('/', UnregistedPasswordIndexController::class)
+            ->name('unregisted-passwords.index');
+        Route::get('/{unregistedPassword}', UnregistedPasswordShowController::class)
+            ->name('unregisted-passwords.show');
+        Route::delete('/', UnregistedPasswordDeleteAllController::class)
+            ->name('unregisted-passwords.delete-all');
+    });
+});

--- a/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\UnregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\UnregistedPassword;
+use Tests\PmappTestCase;
+
+class UnregistedPasswordDeleteAllControllerTest extends PmappTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application = Application::factory()->create();
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        UnregistedPassword::factory()->count(3)->create([
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+        ]);
+    }
+
+    public function test_正常に全件削除できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('unregisted-passwords.delete-all'));
+        $response->assertStatus(200);
+        $this->assertDatabaseCount('unregisted_passwords', 0);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->deleteJson(route('unregisted-passwords.delete-all'));
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\UnregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\UnregistedPassword;
+use Tests\PmappTestCase;
+
+class UnregistedPasswordIndexControllerTest extends PmappTestCase
+{
+    private UnregistedPassword $unregistedPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application = Application::factory()->create();
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        $this->unregistedPassword = UnregistedPassword::factory()->create([
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+            'password' => 'plain-password',
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('unregisted-passwords.index'));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            '*' => [
+                'uuid',
+                'password',
+                'application' => ['id', 'name'],
+                'account' => ['id', 'name'],
+                'created_at',
+            ],
+        ]);
+
+        $response->assertJsonFragment([
+            'uuid' => $this->unregistedPassword->uuid,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('unregisted-passwords.index'));
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordShowControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\UnregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\UnregistedPassword;
+use Illuminate\Support\Str;
+use Tests\PmappTestCase;
+
+class UnregistedPasswordShowControllerTest extends PmappTestCase
+{
+    private UnregistedPassword $unregistedPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application = Application::factory()->create();
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        $this->unregistedPassword = UnregistedPassword::factory()->create([
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+            'password' => 'plain-password',
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('unregisted-passwords.show', [
+            'unregistedPassword' => $this->unregistedPassword->uuid,
+        ]));
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'uuid',
+            'password',
+            'application' => ['id', 'name'],
+            'account' => ['id', 'name'],
+            'created_at',
+        ]);
+        $response->assertJsonFragment([
+            'uuid' => $this->unregistedPassword->uuid,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('unregisted-passwords.show', [
+            'unregistedPassword' => $this->unregistedPassword->uuid,
+        ]));
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないレコード指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('unregisted-passwords.show', [
+            'unregistedPassword' => (string) Str::uuid(),
+        ]));
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #82 の対応として、未登録パスワード管理APIのテストを追加しました。

## 変更内容
- 未登録パスワードAPIのルート追加
  - `GET /api/v2/unregisted-passwords`
  - `GET /api/v2/unregisted-passwords/{unregistedPassword}`
  - `DELETE /api/v2/unregisted-passwords`
- 上記APIの最小コントローラ実装を追加
- Featureテスト追加
  - 一覧: 正常取得 / 未ログイン
  - 詳細: 正常取得 / 未ログイン / 存在しないレコード
  - 全件削除: 正常削除 / 未ログイン

## テスト
- `php artisan test --filter UnregistedPassword`
- 結果: 7 passed

Closes #82