### PR TITLE
feat: 未登録パスワード全件削除APIのレスポンス仕様を定義 (#84)

### DIFF
--- a/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllController.php
+++ b/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllController.php
@@ -12,6 +12,8 @@ class UnregistedPasswordDeleteAllController extends Controller
     public function __invoke(): JsonResponse
     {
         UnregistedPassword::query()->delete();
-        return ApiResponseFormatter::ok();
+        return ApiResponseFormatter::ok([
+            'message' => 'All unregisted passwords deleted successfully.',
+        ]);
     }
 }

--- a/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordDeleteAllControllerTest.php
@@ -30,6 +30,9 @@ class UnregistedPasswordDeleteAllControllerTest extends PmappTestCase
 
         $response = $this->deleteJson(route('unregisted-passwords.delete-all'));
         $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'All unregisted passwords deleted successfully.',
+        ]);
         $this->assertDatabaseCount('unregisted_passwords', 0);
     }
 


### PR DESCRIPTION
## 概要
Issue #84 の要件「削除後のレスポンス仕様（ステータス/メッセージ）を定義」に対応しました。

## 変更内容
- `DELETE /api/v2/unregisted-passwords` のレスポンスにメッセージを追加
  - `{"message": "All unregisted passwords deleted successfully."}`
- Featureテストを更新し、レスポンスメッセージを検証

## テスト
- `php artisan test --filter UnregistedPasswordDeleteAllControllerTest`
- 結果: 2 passed

Closes #84