### PR TITLE
feat: 仮登録パスワード管理の基盤実装 (#89)

### DIFF
--- a/app/Models/PreregistedPassword.php
+++ b/app/Models/PreregistedPassword.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class PreregistedPassword extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'uuid';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'uuid',
+        'password',
+        'application_id',
+        'account_id',
+    ];
+
+    protected static function booted()
+    {
+        static::creating(function ($preregistedPassword) {
+            if (empty($preregistedPassword->uuid)) {
+                $preregistedPassword->uuid = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function setPasswordAttribute($value)
+    {
+        if (empty($value)) {
+            $this->attributes['password'] = $value;
+            return;
+        }
+
+        if (Str::startsWith($value, '$2y$')) {
+            $this->attributes['password'] = $value;
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    public function account()
+    {
+        return $this->belongsTo(Account::class);
+    }
+}

--- a/database/factories/PreregistedPasswordFactory.php
+++ b/database/factories/PreregistedPasswordFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PreregistedPasswordFactory extends Factory
+{
+    protected $model = PreregistedPassword::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'uuid' => (string) Str::uuid(),
+            'password' => $this->faker->password(8),
+            'application_id' => Application::factory(),
+            'account_id' => Account::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_02_23_112000_create_preregisted_passwords_table.php
+++ b/database/migrations/2026_02_23_112000_create_preregisted_passwords_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePreregistedPasswordsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('preregisted_passwords', function (Blueprint $table) {
+            $table->uuid('uuid')->comment('UUID');
+            $table->string('password')->comment('パスワード');
+            $table->unsignedBigInteger('application_id')->comment('アプリケーションID');
+            $table->unsignedBigInteger('account_id')->comment('アカウントID');
+            $table->timestamps();
+
+            $table->primary('uuid');
+            $table->index('application_id');
+            $table->index('account_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('preregisted_passwords');
+    }
+}

--- a/database/seeders/PreregistedPasswordSeeder.php
+++ b/database/seeders/PreregistedPasswordSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Illuminate\Database\Seeder;
+
+class PreregistedPasswordSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        PreregistedPassword::truncate();
+
+        if (Application::count() === 0) {
+            Application::factory()->count(10)->create();
+        }
+
+        if (Account::count() === 0) {
+            Account::factory()->count(30)->create();
+        }
+
+        $accounts = Account::query()->get();
+
+        foreach ($accounts as $account) {
+            PreregistedPassword::factory()->create([
+                'application_id' => $account->application_id,
+                'account_id' => $account->id,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #89 の対応として、仮登録パスワード管理機能の基盤を実装しました。

## 変更内容
- `preregisted_passwords` テーブル作成マイグレーションを追加
- `PreregistedPassword` モデルを追加
  - UUID主キー対応
  - 作成時UUID自動採番
  - `password` の自動ハッシュ化
  - `application` / `account` リレーション定義
- `PreregistedPasswordFactory` を追加
- `PreregistedPasswordSeeder` を追加

## 確認
- `php -l` で追加ファイルの構文エラーがないことを確認
- 既存テスト `php artisan test --filter UnregistedPasswordIndexControllerTest` が通過

Closes #89