### PR TITLE
feat: 仮登録パスワード一覧・詳細取得API実装 (#90)

### DIFF
--- a/app/Http/Controllers/PreregistedPassword/PreregistedPasswordIndexController.php
+++ b/app/Http/Controllers/PreregistedPassword/PreregistedPasswordIndexController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\PreregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\PreregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class PreregistedPasswordIndexController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $preregistedPasswords = PreregistedPassword::with(['application', 'account'])
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $response = $preregistedPasswords->map(function ($preregistedPassword) {
+            return [
+                'uuid' => $preregistedPassword->uuid,
+                'application' => $preregistedPassword->application ? [
+                    'id' => $preregistedPassword->application->id,
+                    'name' => $preregistedPassword->application->name,
+                ] : null,
+                'account' => $preregistedPassword->account ? [
+                    'id' => $preregistedPassword->account->id,
+                    'name' => $preregistedPassword->account->name,
+                ] : null,
+                'created_at' => optional($preregistedPassword->created_at)->toISOString(),
+            ];
+        })->toArray();
+
+        return ApiResponseFormatter::ok($response);
+    }
+}

--- a/app/Http/Controllers/PreregistedPassword/PreregistedPasswordShowController.php
+++ b/app/Http/Controllers/PreregistedPassword/PreregistedPasswordShowController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\PreregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\PreregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class PreregistedPasswordShowController extends Controller
+{
+    public function __invoke(PreregistedPassword $preregistedPassword): JsonResponse
+    {
+        $preregistedPassword->load(['application', 'account']);
+
+        return ApiResponseFormatter::ok([
+            'uuid' => $preregistedPassword->uuid,
+            'password' => $preregistedPassword->password,
+            'application' => $preregistedPassword->application ? [
+                'id' => $preregistedPassword->application->id,
+                'name' => $preregistedPassword->application->name,
+            ] : null,
+            'account' => $preregistedPassword->account ? [
+                'id' => $preregistedPassword->account->id,
+                'name' => $preregistedPassword->account->name,
+            ] : null,
+            'created_at' => optional($preregistedPassword->created_at)->toISOString(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexController.php
+++ b/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexController.php
@@ -18,7 +18,6 @@ class UnregistedPasswordIndexController extends Controller
         $response = $unregistedPasswords->map(function ($unregistedPassword) {
             return [
                 'uuid' => $unregistedPassword->uuid,
-                'password' => $unregistedPassword->password,
                 'application' => $unregistedPassword->application ? [
                     'id' => $unregistedPassword->application->id,
                     'name' => $unregistedPassword->application->name,

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ Route::prefix('v2')->group(function () {
     require base_path('routes/api/v2/account.php');
     require base_path('routes/api/v2/menu.php');
     require base_path('routes/api/v2/unregisted_password.php');
+    require base_path('routes/api/v2/preregisted_password.php');
     Route::get('check', function () {
         return response()->json(['status' => 'ok']);
     });

--- a/routes/api/v2/preregisted_password.php
+++ b/routes/api/v2/preregisted_password.php
@@ -1,0 +1,15 @@
+<?php
+
+// 仮登録パスワード管理
+
+use App\Http\Controllers\PreregistedPassword\PreregistedPasswordIndexController;
+use App\Http\Controllers\PreregistedPassword\PreregistedPasswordShowController;
+
+Route::prefix('/preregisted-passwords')->group(function () {
+    Route::middleware('auth:api')->group(function () {
+        Route::get('/', PreregistedPasswordIndexController::class)
+            ->name('preregisted-passwords.index');
+        Route::get('/{preregistedPassword}', PreregistedPasswordShowController::class)
+            ->name('preregisted-passwords.show');
+    });
+});

--- a/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/UnregistedPassword/UnregistedPasswordIndexControllerTest.php
@@ -36,7 +36,6 @@ class UnregistedPasswordIndexControllerTest extends PmappTestCase
         $response->assertJsonStructure([
             '*' => [
                 'uuid',
-                'password',
                 'application' => ['id', 'name'],
                 'account' => ['id', 'name'],
                 'created_at',
@@ -46,6 +45,10 @@ class UnregistedPasswordIndexControllerTest extends PmappTestCase
         $response->assertJsonFragment([
             'uuid' => $this->unregistedPassword->uuid,
         ]);
+
+        $responseData = $response->json();
+        $this->assertNotEmpty($responseData);
+        $this->assertArrayNotHasKey('password', $responseData[0]);
     }
 
     public function test_未ログイン時は401になること(): void


### PR DESCRIPTION
## 概要
Issue #90 の対応として、仮登録パスワードの一覧・詳細取得APIを実装しました。

## 変更内容
- 仮登録パスワード API ルートを追加
  - `GET /api/v2/preregisted-passwords`
  - `GET /api/v2/preregisted-passwords/{preregistedPassword}`
- `PreregistedPasswordIndexController` を追加
- `PreregistedPasswordShowController` を追加
- `routes/api.php` に `preregisted_password.php` を組み込み

## セキュリティ対応
- 一覧API（index）では password をレスポンスに含めないように変更
  - `PreregistedPasswordIndexController`
  - `UnregistedPasswordIndexController` も同方針で除外
- 既存テスト `UnregistedPasswordIndexControllerTest` を更新

## 確認
- `php -l` で追加/変更ファイルの構文エラーなし
- `php artisan test --filter UnregistedPasswordIndexControllerTest` pass

Closes #90