### PR TITLE
test: 仮登録パスワード管理APIのテスト整備 (#91)

### DIFF
--- a/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordIndexControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\PreregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Tests\PmappTestCase;
+
+class PreregistedPasswordIndexControllerTest extends PmappTestCase
+{
+    private PreregistedPassword $preregistedPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application = Application::factory()->create();
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        $this->preregistedPassword = PreregistedPassword::factory()->create([
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+            'password' => 'plain-password',
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.index'));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            '*' => [
+                'uuid',
+                'application' => ['id', 'name'],
+                'account' => ['id', 'name'],
+                'created_at',
+            ],
+        ]);
+
+        $response->assertJsonFragment([
+            'uuid' => $this->preregistedPassword->uuid,
+        ]);
+
+        $responseData = $response->json();
+        $this->assertNotEmpty($responseData);
+        $this->assertArrayNotHasKey('password', $responseData[0]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('preregisted-passwords.index'));
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordShowControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\PreregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Illuminate\Support\Str;
+use Tests\PmappTestCase;
+
+class PreregistedPasswordShowControllerTest extends PmappTestCase
+{
+    private PreregistedPassword $preregistedPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $application = Application::factory()->create();
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        $this->preregistedPassword = PreregistedPassword::factory()->create([
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+            'password' => 'plain-password',
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.show', [
+            'preregistedPassword' => $this->preregistedPassword->uuid,
+        ]));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'uuid',
+            'password',
+            'application' => ['id', 'name'],
+            'account' => ['id', 'name'],
+            'created_at',
+        ]);
+        $response->assertJsonFragment([
+            'uuid' => $this->preregistedPassword->uuid,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('preregisted-passwords.show', [
+            'preregistedPassword' => $this->preregistedPassword->uuid,
+        ]));
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないレコード指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.show', [
+            'preregistedPassword' => (string) Str::uuid(),
+        ]));
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #91 の対応として、仮登録パスワード管理API（一覧・詳細）のFeatureテストを追加しました。

## 変更内容
- `PreregistedPasswordIndexControllerTest` を追加
  - 正常取得
  - 未ログイン（401）
  - セキュリティ方針として一覧レスポンスに `password` が含まれないことを検証
- `PreregistedPasswordShowControllerTest` を追加
  - 正常取得
  - 未ログイン（401）
  - 存在しないレコード（404）

## テスト
- `php artisan test --filter PreregistedPassword`
- 結果: 5 passed

Closes #91