### PR TITLE
feat: パスワード本登録の基盤実装 (#92)

### DIFF
--- a/app/Models/Password.php
+++ b/app/Models/Password.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class Password extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'password',
+        'application_id',
+        'account_id',
+    ];
+
+    public function setPasswordAttribute($value)
+    {
+        if (empty($value)) {
+            $this->attributes['password'] = $value;
+            return;
+        }
+
+        if (Str::startsWith($value, '$2y$')) {
+            $this->attributes['password'] = $value;
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    public function account()
+    {
+        return $this->belongsTo(Account::class);
+    }
+}

--- a/database/factories/PasswordFactory.php
+++ b/database/factories/PasswordFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\Password;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PasswordFactory extends Factory
+{
+    protected $model = Password::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'password' => $this->faker->password(8),
+            'application_id' => Application::factory(),
+            'account_id' => Account::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_02_23_113000_create_passwords_table.php
+++ b/database/migrations/2026_02_23_113000_create_passwords_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePasswordsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('passwords', function (Blueprint $table) {
+            $table->id();
+            $table->string('password')->comment('パスワード');
+            $table->unsignedBigInteger('application_id')->comment('アプリケーションID');
+            $table->unsignedBigInteger('account_id')->comment('アカウントID');
+            $table->timestamps();
+
+            $table->index('application_id');
+            $table->index('account_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('passwords');
+    }
+}

--- a/database/seeders/PasswordSeeder.php
+++ b/database/seeders/PasswordSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\Password;
+use Illuminate\Database\Seeder;
+
+class PasswordSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Password::truncate();
+
+        if (Application::count() === 0) {
+            Application::factory()->count(10)->create();
+        }
+
+        if (Account::count() === 0) {
+            Account::factory()->count(30)->create();
+        }
+
+        $accounts = Account::query()->get();
+
+        foreach ($accounts as $account) {
+            Password::factory()->create([
+                'application_id' => $account->application_id,
+                'account_id' => $account->id,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #92 の対応として、パスワード本登録機能の基盤を実装しました。

## 変更内容
- `passwords` テーブル作成マイグレーションを追加
  - `id`, `password`, `application_id`, `account_id`, `timestamps`
  - `application_id` / `account_id` にインデックス
- `Password` モデルを追加
  - `password` 自動ハッシュ化
  - `application` / `account` リレーション定義
- `PasswordFactory` を追加
- `PasswordSeeder` を追加

## 確認
- `php -l` で追加ファイルの構文エラーがないことを確認
- 既存テスト `php artisan test --filter PreregistedPasswordIndexControllerTest` が通過

Closes #92