### PR TITLE
test: パスワード作成APIのバリデーションエラーテストを追加

### DIFF
--- a/tests/Feature/app/Http/Controllers/Password/PasswordCreateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Password/PasswordCreateControllerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Password;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\Password;
+use Illuminate\Support\Facades\Hash;
+use Tests\PmappTestCase;
+
+class PasswordCreateControllerTest extends PmappTestCase
+{
+    private Application $application;
+
+    private Account $account;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = Application::factory()->create();
+        $this->account = Account::factory()->create([
+            'application_id' => $this->application->id,
+        ]);
+    }
+
+    public function test_パスワードが正常に作成できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $payload = [
+            'password' => [
+                'password' => 'my-test-password',
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ];
+
+        $response = $this->postJson(route('passwords.create'), $payload);
+        $response->assertOk();
+
+        $this->assertDatabaseHas('passwords', [
+            'application_id' => $this->application->id,
+            'account_id' => $this->account->id,
+        ]);
+
+        $createdPassword = Password::query()
+            ->where('application_id', $this->application->id)
+            ->where('account_id', $this->account->id)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($createdPassword);
+        $this->assertNotEquals('my-test-password', $createdPassword->password);
+        $this->assertTrue(Hash::check('my-test-password', $createdPassword->password));
+    }
+
+    public function test_未ログインの場合は401エラーになること(): void
+    {
+        $payload = [
+            'password' => [
+                'password' => 'my-test-password',
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ];
+
+        $response = $this->postJson(route('passwords.create'), $payload);
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないレコード指定時は422エラーになること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $payload = [
+            'password' => [
+                'password' => 'my-test-password',
+                'application_id' => 999999,
+                'account_id' => 999999,
+            ],
+        ];
+
+        $response = $this->postJson(route('passwords.create'), $payload);
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'password.application_id',
+            'password.account_id',
+        ]);
+    }
+
+    public function test_必須項目が未指定の場合は422エラーになること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('passwords.create'), [
+            'password' => [],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'password.password',
+            'password.application_id',
+            'password.account_id',
+        ]);
+    }
+
+    public function test_パスワードが256文字超の場合は422エラーになること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('passwords.create'), [
+            'password' => [
+                'password' => str_repeat('a', 256),
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['password.password']);
+    }
+
+    public function test_型不正の場合は422エラーになること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('passwords.create'), [
+            'password' => [
+                'password' => ['not-string'],
+                'application_id' => 'invalid-id',
+                'account_id' => 'invalid-id',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'password.password',
+            'password.application_id',
+            'password.account_id',
+        ]);
+    }
+
+    public function test_アプリケーションと紐付かないアカウント指定時は422エラーになること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $otherApplication = Application::factory()->create();
+        $otherAccount = Account::factory()->create([
+            'application_id' => $otherApplication->id,
+        ]);
+
+        $response = $this->postJson(route('passwords.create'), [
+            'password' => [
+                'password' => 'my-test-password',
+                'application_id' => $this->application->id,
+                'account_id' => $otherAccount->id,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['password.account_id']);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #94 の対応として、`passwords.create` のバリデーションエラーに関するFeatureテストを追加しました。

## 変更内容
- `tests/Feature/app/Http/Controllers/Password/PasswordCreateControllerTest.php` を追加
- 以下のケースをテストに追加
  - 必須項目未指定で 422
  - パスワードが 256 文字超で 422
  - 型不正（password が string 以外、application_id/account_id が integer 以外）で 422
  - application_id と account_id の紐付け不一致で 422
- 既存の正常系/未認証/存在しないID指定ケースも含め、合計7ケース

## 確認
- `php -l tests/Feature/app/Http/Controllers/Password/PasswordCreateControllerTest.php`
- `php artisan test --filter PasswordCreateControllerTest`

## 関連Issue
- Closes #94