### PR TITLE
Issue #105 パスワード一覧取得APIを実装

### DIFF
--- a/app/Http/Controllers/Password/PasswordIndexController.php
+++ b/app/Http/Controllers/Password/PasswordIndexController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Password;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Password\PasswordIndexRequest;
+use App\Models\Application;
+use Illuminate\Http\JsonResponse;
+
+class PasswordIndexController extends Controller
+{
+    public function __invoke(PasswordIndexRequest $request): JsonResponse
+    {
+        $applicationId = $request->input('application_id');
+
+        $applications = Application::query()
+            ->with(['accounts'])
+            ->when($applicationId, function ($query, $applicationId) {
+                $query->where('id', $applicationId);
+            })
+            ->orderBy('id')
+            ->get();
+
+        $response = [];
+
+        foreach ($applications as $application) {
+            if ($application->account_class) {
+                foreach ($application->accounts->sortBy('id') as $account) {
+                    $response[] = [
+                        'application' => [
+                            'id' => $application->id,
+                            'name' => $application->name,
+                        ],
+                        'account' => [
+                            'id' => $account->id,
+                            'name' => $account->name,
+                        ],
+                    ];
+                }
+                continue;
+            }
+
+            $response[] = [
+                'application' => [
+                    'id' => $application->id,
+                    'name' => $application->name,
+                ],
+                'account' => null,
+            ];
+        }
+
+        return ApiResponseFormatter::ok($response);
+    }
+}

--- a/app/Http/Requests/Password/PasswordIndexRequest.php
+++ b/app/Http/Requests/Password/PasswordIndexRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Password;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PasswordIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'application_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('applications', 'id')->whereNull('deleted_at'),
+            ],
+        ];
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -44,4 +44,9 @@ class Application extends Model
         'mark_class',
         'pre_password_size',
     ];
+
+    public function accounts()
+    {
+        return $this->hasMany(Account::class);
+    }
 }

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -174,7 +174,8 @@ return [
             'name' => 'アカウント名',
             'application_id' => 'アプリケーション',
             'notice_class' => '定期通知区分',
-        ]
+        ],
+        'application_id' => 'アプリケーション',
     ],
 
 ];

--- a/routes/api/v2/password.php
+++ b/routes/api/v2/password.php
@@ -3,9 +3,12 @@
 // パスワード本登録
 
 use App\Http\Controllers\Password\PasswordCreateController;
+use App\Http\Controllers\Password\PasswordIndexController;
 
 Route::prefix('/passwords')->group(function () {
     Route::middleware('auth:api')->group(function () {
+        Route::get('/', PasswordIndexController::class)
+            ->name('passwords.index');
         Route::post('/', PasswordCreateController::class)
             ->name('passwords.create');
     });

--- a/tests/Feature/app/Http/Controllers/Password/PasswordIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Password/PasswordIndexControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Password;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class PasswordIndexControllerTest extends PmappTestCase
+{
+    private Application $targetApplication;
+
+    private Account $account1;
+
+    private Account $account2;
+
+    private Application $accountClassFalseApplication;
+
+    private Application $deletedApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->targetApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->account1 = Account::factory()->create([
+            'application_id' => $this->targetApplication->id,
+            'name' => 'Account 1',
+        ]);
+        $this->account2 = Account::factory()->create([
+            'application_id' => $this->targetApplication->id,
+            'name' => 'Account 2',
+        ]);
+
+        $this->accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+        Account::factory()->create([
+            'application_id' => $this->accountClassFalseApplication->id,
+            'name' => 'Ignored Account',
+        ]);
+
+        $this->deletedApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+        $this->deletedApplication->delete();
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('passwords.index'));
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(3);
+
+        $response->assertJsonFragment([
+            'application' => [
+                'id' => $this->targetApplication->id,
+                'name' => $this->targetApplication->name,
+            ],
+            'account' => [
+                'id' => $this->account1->id,
+                'name' => $this->account1->name,
+            ],
+        ]);
+        $response->assertJsonFragment([
+            'application' => [
+                'id' => $this->targetApplication->id,
+                'name' => $this->targetApplication->name,
+            ],
+            'account' => [
+                'id' => $this->account2->id,
+                'name' => $this->account2->name,
+            ],
+        ]);
+        $response->assertJsonFragment([
+            'application' => [
+                'id' => $this->accountClassFalseApplication->id,
+                'name' => $this->accountClassFalseApplication->name,
+            ],
+            'account' => null,
+        ]);
+
+        $response->assertJsonMissing([
+            'application' => [
+                'id' => $this->deletedApplication->id,
+                'name' => $this->deletedApplication->name,
+            ],
+        ]);
+    }
+
+    public function test_application_idで絞り込みできること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('passwords.index', [
+            'application_id' => $this->targetApplication->id,
+        ]));
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([
+            'application' => [
+                'id' => $this->targetApplication->id,
+                'name' => $this->targetApplication->name,
+            ],
+        ]);
+        $response->assertJsonMissing([
+            'application' => [
+                'id' => $this->accountClassFalseApplication->id,
+                'name' => $this->accountClassFalseApplication->name,
+            ],
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('passwords.index'));
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないapplication_id指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('passwords.index', [
+            'application_id' => 999999,
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['application_id']);
+    }
+}


### PR DESCRIPTION
## Issue
https://github.com/Yu-Mo-13/pmapp-back-v2/issues/105

## 概要
- `GET /api/v2/passwords`（`passwords.index`）を追加
- 一覧取得を `Application` 起点へ変更し、`account_class` の仕様に応じてレスポンスを生成
- `application_id` クエリのバリデーション（存在チェック、論理削除除外）を追加
- 一覧APIのFeatureテストを追加（正常系、フィルタ、未ログイン、存在しないID）
- 日本語バリデーション属性に `application_id` を追加