### PR TITLE
未作成APIのFeatureテストを追加

### DIFF
--- a/tests/Feature/app/Http/Controllers/Account/AccountApplicationIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountApplicationIndexControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountApplicationIndexControllerTest extends PmappTestCase
+{
+    private Application $accountClassTrueApplication1;
+
+    private Application $accountClassTrueApplication2;
+
+    private Application $accountClassFalseApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->accountClassTrueApplication1 = Application::factory()->create([
+            'name' => 'Account Enabled App 1',
+            'account_class' => true,
+        ]);
+        $this->accountClassTrueApplication2 = Application::factory()->create([
+            'name' => 'Account Enabled App 2',
+            'account_class' => true,
+        ]);
+        $this->accountClassFalseApplication = Application::factory()->create([
+            'name' => 'Account Disabled App',
+            'account_class' => false,
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('accounts.applications'));
+
+        $response->assertOk();
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([
+            'id' => $this->accountClassTrueApplication1->id,
+            'name' => $this->accountClassTrueApplication1->name,
+        ]);
+        $response->assertJsonFragment([
+            'id' => $this->accountClassTrueApplication2->id,
+            'name' => $this->accountClassTrueApplication2->name,
+        ]);
+        $response->assertJsonMissing([
+            'id' => $this->accountClassFalseApplication->id,
+            'name' => $this->accountClassFalseApplication->name,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('accounts.applications'));
+
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Account/AccountCreateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountCreateControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountCreateControllerTest extends PmappTestCase
+{
+    private Application $creatableApplication;
+
+    private Application $nonCreatableApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->creatableApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->nonCreatableApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+    }
+
+    public function test_アカウントが正常に作成できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $payload = [
+            'account' => [
+                'name' => 'New Account',
+                'application_id' => $this->creatableApplication->id,
+                'notice_class' => true,
+            ],
+        ];
+
+        $response = $this->postJson(route('accounts'), $payload);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('accounts', $payload['account']);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->postJson(route('accounts'), [
+            'account' => [
+                'name' => 'New Account',
+                'application_id' => $this->creatableApplication->id,
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_必須項目未指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('accounts'), [
+            'account' => [],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'account.name',
+            'account.application_id',
+            'account.notice_class',
+        ]);
+    }
+
+    public function test_型不正時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('accounts'), [
+            'account' => [
+                'name' => ['invalid'],
+                'application_id' => 'invalid-id',
+                'notice_class' => 'yes',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'account.name',
+            'account.application_id',
+            'account.notice_class',
+        ]);
+    }
+
+    public function test_重複したアカウント名指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $existingAccount = Account::factory()->create([
+            'application_id' => $this->creatableApplication->id,
+            'name' => 'Duplicated Account',
+        ]);
+
+        $response = $this->postJson(route('accounts'), [
+            'account' => [
+                'name' => $existingAccount->name,
+                'application_id' => $this->creatableApplication->id,
+                'notice_class' => false,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['account.name']);
+    }
+
+    public function test_account_class_falseのアプリケーション指定時は403になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('accounts'), [
+            'account' => [
+                'name' => 'Forbidden Account',
+                'application_id' => $this->nonCreatableApplication->id,
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseMissing('accounts', [
+            'name' => 'Forbidden Account',
+            'application_id' => $this->nonCreatableApplication->id,
+        ]);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Account/AccountDeleteControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountDeleteControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountDeleteControllerTest extends PmappTestCase
+{
+    private Account $targetAccount;
+
+    private Account $accountClassFalseApplicationAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $targetApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->targetAccount = Account::factory()->create([
+            'application_id' => $targetApplication->id,
+        ]);
+
+        $accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+        $this->accountClassFalseApplicationAccount = Account::factory()->create([
+            'application_id' => $accountClassFalseApplication->id,
+        ]);
+    }
+
+    public function test_アカウントが正常に削除できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('account', ['account' => $this->targetAccount->id]));
+
+        $response->assertOk();
+        $this->assertSoftDeleted('accounts', [
+            'id' => $this->targetAccount->id,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->deleteJson(route('account', ['account' => $this->targetAccount->id]));
+
+        $response->assertStatus(401);
+    }
+
+    public function test_account_class_falseのアプリケーションに紐づく場合は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('account', ['account' => $this->accountClassFalseApplicationAccount->id]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しないアカウントID指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('account', ['account' => 999999]));
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Account/AccountIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountIndexControllerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountIndexControllerTest extends PmappTestCase
+{
+    private Application $targetApplication;
+
+    private Account $account1;
+
+    private Account $account2;
+
+    private Application $ignoredApplication;
+
+    private Account $ignoredAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->targetApplication = Application::factory()->create([
+            'name' => 'Target App',
+            'account_class' => true,
+        ]);
+
+        $this->account1 = Account::factory()->create([
+            'name' => 'Account 1',
+            'application_id' => $this->targetApplication->id,
+            'notice_class' => true,
+        ]);
+        $this->account2 = Account::factory()->create([
+            'name' => 'Account 2',
+            'application_id' => $this->targetApplication->id,
+            'notice_class' => false,
+        ]);
+
+        $this->ignoredApplication = Application::factory()->create([
+            'name' => 'Ignored App',
+            'account_class' => false,
+        ]);
+        $this->ignoredAccount = Account::factory()->create([
+            'name' => 'Ignored Account',
+            'application_id' => $this->ignoredApplication->id,
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('accounts'));
+
+        $response->assertOk();
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([
+            'id' => $this->account1->id,
+            'name' => $this->account1->name,
+            'application_id' => $this->targetApplication->id,
+            'application_name' => $this->targetApplication->name,
+            'notice_class' => (int) $this->account1->notice_class,
+        ]);
+        $response->assertJsonFragment([
+            'id' => $this->account2->id,
+            'name' => $this->account2->name,
+            'application_id' => $this->targetApplication->id,
+            'application_name' => $this->targetApplication->name,
+            'notice_class' => (int) $this->account2->notice_class,
+        ]);
+        $response->assertJsonMissing([
+            'id' => $this->ignoredAccount->id,
+            'name' => $this->ignoredAccount->name,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('accounts'));
+
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Account/AccountShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountShowControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountShowControllerTest extends PmappTestCase
+{
+    private Account $targetAccount;
+
+    private Account $accountClassFalseApplicationAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $targetApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->targetAccount = Account::factory()->create([
+            'application_id' => $targetApplication->id,
+        ]);
+
+        $accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+        $this->accountClassFalseApplicationAccount = Account::factory()->create([
+            'application_id' => $accountClassFalseApplication->id,
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('account', ['account' => $this->targetAccount->id]));
+
+        $response->assertOk();
+        $response->assertJson([
+            'id' => $this->targetAccount->id,
+            'name' => $this->targetAccount->name,
+            'application_id' => $this->targetAccount->application_id,
+            'notice_class' => $this->targetAccount->notice_class,
+        ]);
+        $responseData = $response->json();
+        $this->assertArrayNotHasKey('created_at', $responseData);
+        $this->assertArrayNotHasKey('updated_at', $responseData);
+    }
+
+    public function test_account_class_falseのアプリケーションに紐づく場合は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('account', ['account' => $this->accountClassFalseApplicationAccount->id]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しないアカウントID指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('account', ['account' => 999999]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('account', ['account' => $this->targetAccount->id]));
+
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Account/AccountUpdateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Account/AccountUpdateControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Account;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class AccountUpdateControllerTest extends PmappTestCase
+{
+    private Account $targetAccount;
+
+    private Account $otherAccount;
+
+    private Account $accountClassFalseApplicationAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $targetApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->targetAccount = Account::factory()->create([
+            'name' => 'Target Account',
+            'application_id' => $targetApplication->id,
+            'notice_class' => false,
+        ]);
+        $this->otherAccount = Account::factory()->create([
+            'name' => 'Other Account',
+            'application_id' => $targetApplication->id,
+        ]);
+
+        $accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+        ]);
+        $this->accountClassFalseApplicationAccount = Account::factory()->create([
+            'application_id' => $accountClassFalseApplication->id,
+        ]);
+    }
+
+    public function test_アカウントが正常に更新できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => $this->targetAccount->id]), [
+            'account' => [
+                'name' => 'Updated Account',
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('accounts', [
+            'id' => $this->targetAccount->id,
+            'name' => 'Updated Account',
+            'notice_class' => true,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->putJson(route('account', ['account' => $this->targetAccount->id]), [
+            'account' => [
+                'name' => 'Updated Account',
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_必須項目未指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => $this->targetAccount->id]), [
+            'account' => [],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'account.name',
+            'account.notice_class',
+        ]);
+    }
+
+    public function test_application_idを指定すると422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => $this->targetAccount->id]), [
+            'account' => [
+                'name' => 'Updated Account',
+                'application_id' => $this->targetAccount->application_id,
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['account.application_id']);
+    }
+
+    public function test_重複したアカウント名指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => $this->targetAccount->id]), [
+            'account' => [
+                'name' => $this->otherAccount->name,
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['account.name']);
+    }
+
+    public function test_account_class_falseのアプリケーションに紐づく場合は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => $this->accountClassFalseApplicationAccount->id]), [
+            'account' => [
+                'name' => 'Updated Account',
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しないアカウントID指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('account', ['account' => 999999]), [
+            'account' => [
+                'name' => 'Updated Account',
+                'notice_class' => true,
+            ],
+        ]);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Application/ApplicationDeleteControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Application/ApplicationDeleteControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Application;
+
+use Tests\PmappTestCase;
+
+class ApplicationDeleteControllerTest extends PmappTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpApplication();
+    }
+
+    public function test_アプリケーションが正常に削除できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('applications.delete', ['application' => $this->accountClassTrueApplication->id]));
+
+        $response->assertOk();
+        $this->assertSoftDeleted('applications', [
+            'id' => $this->accountClassTrueApplication->id,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->deleteJson(route('applications.delete', ['application' => $this->accountClassTrueApplication->id]));
+
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないアプリケーションID指定時は404になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->deleteJson(route('applications.delete', ['application' => 999999]));
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Application/ApplicationUpdateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Application/ApplicationUpdateControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Application;
+
+use Tests\PmappTestCase;
+
+class ApplicationUpdateControllerTest extends PmappTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpApplication();
+    }
+
+    public function test_アプリケーションが正常に更新できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $payload = [
+            'application' => [
+                'name' => 'Updated Application',
+                'account_class' => true,
+                'notice_class' => true,
+                'mark_class' => false,
+                'pre_password_size' => 12,
+            ],
+        ];
+
+        $response = $this->putJson(route('applications.update', ['application' => $this->accountClassTrueApplication->id]), $payload);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('applications', [
+            'id' => $this->accountClassTrueApplication->id,
+            'name' => 'Updated Application',
+            'account_class' => true,
+            'notice_class' => true,
+            'mark_class' => false,
+            'pre_password_size' => 12,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->putJson(route('applications.update', ['application' => $this->accountClassTrueApplication->id]), [
+            'application' => [
+                'name' => 'Updated Application',
+                'account_class' => true,
+                'notice_class' => true,
+                'mark_class' => false,
+                'pre_password_size' => 12,
+            ],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_必須項目未指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('applications.update', ['application' => $this->accountClassTrueApplication->id]), [
+            'application' => [],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'application.name',
+            'application.account_class',
+            'application.notice_class',
+            'application.mark_class',
+            'application.pre_password_size',
+        ]);
+    }
+
+    public function test_重複したアプリケーション名指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('applications.update', ['application' => $this->accountClassTrueApplication->id]), [
+            'application' => [
+                'name' => $this->markClassTrueApplication->name,
+                'account_class' => true,
+                'notice_class' => false,
+                'mark_class' => false,
+                'pre_password_size' => 8,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['application.name']);
+    }
+
+    public function test_仮登録パスワード桁数が1未満の時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->putJson(route('applications.update', ['application' => $this->accountClassTrueApplication->id]), [
+            'application' => [
+                'name' => 'Updated Application',
+                'account_class' => true,
+                'notice_class' => true,
+                'mark_class' => true,
+                'pre_password_size' => 0,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['application.pre_password_size']);
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Auth;
+
+use App\Services\SupabaseAuthService;
+use Exception;
+use Mockery;
+use Tests\PmappTestCase;
+
+class LoginControllerTest extends PmappTestCase
+{
+    public function test_ログインが成功すること(): void
+    {
+        $user = $this->webUser;
+        $user->update([
+            'email' => 'login-success@example.com',
+            'uid' => 'uid-success',
+        ]);
+
+        $mock = Mockery::mock(SupabaseAuthService::class);
+        $mock->shouldReceive('signIn')
+            ->once()
+            ->with('login-success@example.com', 'test-password')
+            ->andReturn([
+                'access_token' => 'test-token',
+            ]);
+        $this->app->instance(SupabaseAuthService::class, $mock);
+
+        $response = $this->postJson(route('auth.login'), [
+            'email' => 'login-success@example.com',
+            'password' => 'test-password',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'access_token' => 'test-token',
+        ]);
+    }
+
+    public function test_バリデーションエラー時は422になること(): void
+    {
+        $response = $this->postJson(route('auth.login'), [
+            'email' => 'invalid-email',
+            'password' => '',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'email',
+            'password',
+        ]);
+    }
+
+    public function test_ユーザーが存在しない場合は422になること(): void
+    {
+        $response = $this->postJson(route('auth.login'), [
+            'email' => 'not-found@example.com',
+            'password' => 'test-password',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'ログインに失敗しました。',
+        ]);
+    }
+
+    public function test_supabase認証に失敗した場合は422になること(): void
+    {
+        $user = $this->webUser;
+        $user->update([
+            'email' => 'login-fail@example.com',
+            'uid' => 'uid-fail',
+        ]);
+
+        $mock = Mockery::mock(SupabaseAuthService::class);
+        $mock->shouldReceive('signIn')
+            ->once()
+            ->with('login-fail@example.com', 'test-password')
+            ->andThrow(new Exception('Auth failed'));
+        $this->app->instance(SupabaseAuthService::class, $mock);
+
+        $response = $this->postJson(route('auth.login'), [
+            'email' => 'login-fail@example.com',
+            'password' => 'test-password',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'ログインに失敗しました。',
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要
未作成だったAPIのFeatureテストを、既存の`tests/Feature/app/Http/Controllers/Password`配下の観点に合わせて追加しました。

## 追加したテスト
- Application
  - `ApplicationUpdateControllerTest`
  - `ApplicationDeleteControllerTest`
- Account
  - `AccountApplicationIndexControllerTest`
  - `AccountIndexControllerTest`
  - `AccountShowControllerTest`
  - `AccountCreateControllerTest`
  - `AccountUpdateControllerTest`
  - `AccountDeleteControllerTest`
- Auth
  - `LoginControllerTest`（`SupabaseAuthService`はモック化）

## テスト観点
- 正常系
- 未ログイン時の401
- バリデーションエラー（422）
- 業務条件エラー（403/404）

## 実行コマンド
- `php artisan test tests/Feature/app/Http/Controllers/Application/ApplicationUpdateControllerTest.php`
- `php artisan test tests/Feature/app/Http/Controllers/Application/ApplicationDeleteControllerTest.php`
- `php artisan test tests/Feature/app/Http/Controllers/Account`
- `php artisan test tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php`

上記はすべてpass済みです（実行環境由来のDeprecated警告は出力あり）。

## Close Issues
Closes #15 
Closes #34
Closes #36
Closes #48
Closes #51
Closes #57
Closes #63
Closes #64
Closes #65