### PR TITLE
feat: add accounts list API by application id

### DIFF
--- a/app/Http/Controllers/Application/ApplicationAccountIndexController.php
+++ b/app/Http/Controllers/Application/ApplicationAccountIndexController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Application;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\Application;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+
+class ApplicationAccountIndexController extends Controller
+{
+    public function __invoke(Application $application): JsonResponse
+    {
+        $accounts = $application->accounts()
+            ->orderBy('id')
+            ->get();
+
+        return ApiResponseFormatter::ok($this->transformAccounts($accounts));
+    }
+
+    private function transformAccounts(Collection $accounts): array
+    {
+        return $accounts->map(fn($account) => [
+            'id' => $account->id,
+            'name' => $account->name,
+        ])->toArray();
+    }
+}

--- a/routes/api/v2/application.php
+++ b/routes/api/v2/application.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Application\ApplicationCreateController;
 use App\Http\Controllers\Application\ApplicationShowController;
 use App\Http\Controllers\Application\ApplicationUpdateController;
 use App\Http\Controllers\Application\ApplicationDeleteController;
+use App\Http\Controllers\Application\ApplicationAccountIndexController;
 
 Route::prefix('/applications')->group(function () {
     Route::middleware('auth:api')->group(function () {
@@ -16,6 +17,8 @@ Route::prefix('/applications')->group(function () {
             ->name('applications.create');
         Route::get('/{application}', ApplicationShowController::class)
             ->name('applications.show');
+        Route::get('/{application}/accounts', ApplicationAccountIndexController::class)
+            ->name('applications.accounts');
         Route::put('/{application}', ApplicationUpdateController::class)
             ->name('applications.update');
         Route::delete('/{application}', ApplicationDeleteController::class)

--- a/tests/Feature/app/Http/Controllers/Application/ApplicationAccountIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Application/ApplicationAccountIndexControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\Application;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class ApplicationAccountIndexControllerTest extends PmappTestCase
+{
+    private Application $targetApplication;
+
+    private Application $otherApplication;
+
+    private Account $targetAccount1;
+
+    private Account $targetAccount2;
+
+    private Account $otherAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->targetApplication = Application::factory()->create([
+            'name' => 'Target App',
+        ]);
+
+        $this->otherApplication = Application::factory()->create([
+            'name' => 'Other App',
+        ]);
+
+        $this->targetAccount1 = Account::factory()->create([
+            'name' => 'Target Account 1',
+            'application_id' => $this->targetApplication->id,
+        ]);
+        $this->targetAccount2 = Account::factory()->create([
+            'name' => 'Target Account 2',
+            'application_id' => $this->targetApplication->id,
+        ]);
+        $this->otherAccount = Account::factory()->create([
+            'name' => 'Other Account',
+            'application_id' => $this->otherApplication->id,
+        ]);
+    }
+
+    public function test_正常取得できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('applications.accounts', ['application' => $this->targetApplication->id]));
+
+        $response->assertOk();
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment([
+            'id' => $this->targetAccount1->id,
+            'name' => $this->targetAccount1->name,
+        ]);
+        $response->assertJsonFragment([
+            'id' => $this->targetAccount2->id,
+            'name' => $this->targetAccount2->name,
+        ]);
+        $response->assertJsonMissing([
+            'id' => $this->otherAccount->id,
+            'name' => $this->otherAccount->name,
+        ]);
+    }
+
+    public function test_存在しないアプリケーションIDを指定した場合は404エラー(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('applications.accounts', ['application' => 999999]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('applications.accounts', ['application' => $this->targetApplication->id]));
+
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GET /api/v2/applications/{application}/accounts`
- return only account `id` and `name` for the specified application
- add feature tests for success, 404 (non-existent application), and 401 (unauthenticated)

## Test
- `php artisan test --filter=ApplicationAccountIndexControllerTest`

Closes #111