### PR TITLE
#141 ログインAPIレスポンスにトップページURLを追加

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -26,12 +26,13 @@ class LoginController extends Controller
         $email = $request->input('email');
         $password = $request->input('password');
 
-        $isExist = User::where('email', $email)
+        $user = User::with('role')
+            ->where('email', $email)
             ->whereNotNull('uid')
             ->whereNull('deleted_at')
-            ->exists();
+            ->first();
 
-        if (!$isExist) {
+        if (!$user) {
             \Log::info('ユーザーが見つかりませんでした。');
             return ApiResponseFormatter::unprocessible('ログインに失敗しました。');
         }
@@ -42,6 +43,7 @@ class LoginController extends Controller
 
             return ApiResponseFormatter::ok([
                 'access_token' => $authResult['access_token'],
+                'top_page_url' => $user->role?->top_page_url,
             ]);
         } catch (Exception $e) {
             info("Login failed for user: $email - " . $e->getMessage());

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -43,7 +43,7 @@ class LoginController extends Controller
 
             return ApiResponseFormatter::ok([
                 'access_token' => $authResult['access_token'],
-                'top_page_url' => $user->role?->top_page_url,
+                'top_page_url' => $user->role->top_page_url,
             ]);
         } catch (Exception $e) {
             info("Login failed for user: $email - " . $e->getMessage());

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $id
  * @property string $name ロール名
  * @property string $code ロールコード
+ * @property string|null $top_page_url トップページURL
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @method static \Database\Factories\RoleFactory factory(...$parameters)
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Role whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Role whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Role whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereTopPageUrl($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Role whereUpdatedAt($value)
  * @mixin \Eloquent
  */
@@ -36,5 +38,6 @@ class Role extends Model
     protected $fillable = [
         'name',
         'code',
+        'top_page_url',
     ];
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $id
  * @property string $name ロール名
  * @property string $code ロールコード
- * @property string|null $top_page_url トップページURL
+ * @property string $top_page_url トップページURL
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @method static \Database\Factories\RoleFactory factory(...$parameters)

--- a/app/Services/OpenApiSpecificationFactory.php
+++ b/app/Services/OpenApiSpecificationFactory.php
@@ -330,8 +330,9 @@ class OpenApiSpecificationFactory
                 'type' => 'object',
                 'properties' => [
                     'access_token' => ['type' => 'string'],
+                    'top_page_url' => ['type' => 'string'],
                 ],
-                'required' => ['access_token'],
+                'required' => ['access_token', 'top_page_url'],
             ],
             'LoginStatusResponse' => [
                 'type' => 'object',

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -17,6 +17,7 @@ class RoleFactory extends Factory
         return [
             'name' => $this->faker->word,
             'code' => $this->faker->unique()->word,
+            'top_page_url' => '/passwords',
         ];
     }
 
@@ -25,6 +26,7 @@ class RoleFactory extends Factory
         return $this->state([
             'name' => RoleEnum::getDescription(RoleEnum::ADMIN),
             'code' => RoleEnum::ADMIN,
+            'top_page_url' => '/applications',
         ]);
     }
 
@@ -33,6 +35,7 @@ class RoleFactory extends Factory
         return $this->state([
             'name' => RoleEnum::getDescription(RoleEnum::WEB_USER),
             'code' => RoleEnum::WEB_USER,
+            'top_page_url' => '/passwords',
         ]);
     }
 
@@ -41,6 +44,7 @@ class RoleFactory extends Factory
         return $this->state([
             'name' => RoleEnum::getDescription(RoleEnum::MOBILE_USER),
             'code' => RoleEnum::MOBILE_USER,
+            'top_page_url' => '/passwords',
         ]);
     }
 }

--- a/database/migrations/2026_04_18_150000_add_top_page_url_to_roles_table.php
+++ b/database/migrations/2026_04_18_150000_add_top_page_url_to_roles_table.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Http\Enums\Role\RoleEnum;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class AddTopPageUrlToRolesTable extends Migration
@@ -13,9 +15,31 @@ class AddTopPageUrlToRolesTable extends Migration
      */
     public function up()
     {
+        if (DB::getDriverName() === 'sqlite') {
+            Schema::table('roles', function (Blueprint $table) {
+                $table->string('top_page_url')->after('code')->comment('トップページURL');
+            });
+
+            return;
+        }
+
         Schema::table('roles', function (Blueprint $table) {
             $table->string('top_page_url')->nullable()->after('code')->comment('トップページURL');
         });
+
+        DB::table('roles')
+            ->where('code', RoleEnum::ADMIN)
+            ->update(['top_page_url' => '/applications']);
+
+        DB::table('roles')
+            ->whereIn('code', [RoleEnum::WEB_USER, RoleEnum::MOBILE_USER])
+            ->update(['top_page_url' => '/passwords']);
+
+        DB::table('roles')
+            ->whereNull('top_page_url')
+            ->update(['top_page_url' => '/passwords']);
+
+        DB::statement('ALTER TABLE roles ALTER COLUMN top_page_url SET NOT NULL');
     }
 
     /**

--- a/database/migrations/2026_04_18_150000_add_top_page_url_to_roles_table.php
+++ b/database/migrations/2026_04_18_150000_add_top_page_url_to_roles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTopPageUrlToRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('top_page_url')->nullable()->after('code')->comment('トップページURL');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('top_page_url');
+        });
+    }
+}

--- a/tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php
@@ -16,6 +16,9 @@ class LoginControllerTest extends PmappTestCase
             'email' => 'login-success@example.com',
             'uid' => 'uid-success',
         ]);
+        $user->role->update([
+            'top_page_url' => '/passwords',
+        ]);
 
         $mock = Mockery::mock(SupabaseAuthService::class);
         $mock->shouldReceive('signIn')
@@ -34,6 +37,7 @@ class LoginControllerTest extends PmappTestCase
         $response->assertOk();
         $response->assertJson([
             'access_token' => 'test-token',
+            'top_page_url' => '/passwords',
         ]);
     }
 

--- a/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
@@ -53,6 +53,14 @@ class OpenApiSpecificationShowControllerTest extends TestCase
             $specification['paths']['/api/v2/login']['post']['responses']['422']['content']['application/json']['schema']['$ref']
         );
         $this->assertSame(
+            'string',
+            $specification['components']['schemas']['LoginResponse']['properties']['top_page_url']['type']
+        );
+        $this->assertContains(
+            'top_page_url',
+            $specification['components']['schemas']['LoginResponse']['required']
+        );
+        $this->assertSame(
             '#/components/schemas/UnauthorizedResponse',
             $specification['paths']['/api/v2/accounts']['get']['responses']['401']['content']['application/json']['schema']['$ref']
         );

--- a/tests/PmappTestCase.php
+++ b/tests/PmappTestCase.php
@@ -57,14 +57,17 @@ class PmappTestCase extends TestCase
         $this->adminRole = Role::factory()->create([
             'name' => RoleEnum::getDescription(RoleEnum::ADMIN),
             'code' => RoleEnum::ADMIN,
+            'top_page_url' => '/applications',
         ]);
         $this->webUserRole = Role::factory()->create([
             'name' => RoleEnum::getDescription(RoleEnum::WEB_USER),
             'code' => RoleEnum::WEB_USER,
+            'top_page_url' => '/passwords',
         ]);
         $this->mobileUserRole = Role::factory()->create([
             'name' => RoleEnum::getDescription(RoleEnum::MOBILE_USER),
             'code' => RoleEnum::MOBILE_USER,
+            'top_page_url' => '/passwords',
         ]);
 
         // ユーザーの作成


### PR DESCRIPTION
## What
- `roles` テーブルに `top_page_url` カラムを追加
- ログインAPIレスポンスに、ユーザーのロールに応じた `top_page_url` を含めるよう変更
- OpenAPI/Swagger の `LoginResponse` スキーマを更新
- ロールの factory / テスト初期データにトップページURLを設定

## Why
ログイン後の初期遷移先をフロントエンドがロールごとに判断できるようにするためです。

## Impact
- 管理者ユーザーは `/applications`
- 一般ユーザーとモバイルユーザーは `/passwords`
- ログインAPI利用側は `access_token` に加えて `top_page_url` を受け取れます
- DB マイグレーションが必要です

## Root Cause
これまでログインAPIはアクセストークンしか返しておらず、初期表示ページの情報をレスポンスに含めていませんでした。

## Validation
- `php artisan test tests/Feature/app/Http/Controllers/Auth/LoginControllerTest.php`
- `php artisan test tests/Feature/app/Http/Controllers/Auth`
- `php artisan test tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php`