### PR TITLE
#143 Add role code to login status

### DIFF
--- a/app/Http/Controllers/Auth/LoginStatusController.php
+++ b/app/Http/Controllers/Auth/LoginStatusController.php
@@ -22,11 +22,15 @@ class LoginStatusController extends Controller
             $user = Auth::user();
             return ApiResponseFormatter::ok([
                 'name' => $user->name,
+                'role' => [
+                    'code' => $user->role?->code,
+                ],
             ]);
         } catch (\Exception $e) {
             info('Error fetching login status: ' . $e->getMessage());
             return ApiResponseFormatter::ok([
                 'name' => 'ゲスト',
+                'role' => null,
             ]);
         }
     }

--- a/app/Services/OpenApiSpecificationFactory.php
+++ b/app/Services/OpenApiSpecificationFactory.php
@@ -338,8 +338,16 @@ class OpenApiSpecificationFactory
                 'type' => 'object',
                 'properties' => [
                     'name' => ['type' => 'string'],
+                    'role' => [
+                        'type' => 'object',
+                        'nullable' => true,
+                        'properties' => [
+                            'code' => ['type' => 'string'],
+                        ],
+                        'required' => ['code'],
+                    ],
                 ],
-                'required' => ['name'],
+                'required' => ['name', 'role'],
             ],
             'ApplicationResponse' => [
                 'type' => 'object',

--- a/tests/Feature/app/Http/Controllers/Auth/LoginStatusControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Auth/LoginStatusControllerTest.php
@@ -18,6 +18,7 @@ class LoginStatusControllerTest extends PmappTestCase
         $response->assertOk()
             ->assertJson([
                 'name' => 'ゲスト',
+                'role' => null,
             ]);
     }
 
@@ -31,6 +32,9 @@ class LoginStatusControllerTest extends PmappTestCase
         $response->assertOk()
             ->assertJson([
                 'name' => $user->name,
+                'role' => [
+                    'code' => $user->role->code,
+                ],
             ]);
     }
 
@@ -44,6 +48,9 @@ class LoginStatusControllerTest extends PmappTestCase
         $response->assertOk()
             ->assertJson([
                 'name' => $user->name,
+                'role' => [
+                    'code' => $user->role->code,
+                ],
             ]);
     }
 }

--- a/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
@@ -56,6 +56,17 @@ class OpenApiSpecificationShowControllerTest extends TestCase
             'string',
             $specification['components']['schemas']['LoginResponse']['properties']['top_page_url']['type']
         );
+        $this->assertSame(
+            'string',
+            $specification['components']['schemas']['LoginStatusResponse']['properties']['role']['properties']['code']['type']
+        );
+        $this->assertTrue(
+            $specification['components']['schemas']['LoginStatusResponse']['properties']['role']['nullable']
+        );
+        $this->assertContains(
+            'role',
+            $specification['components']['schemas']['LoginStatusResponse']['required']
+        );
         $this->assertContains(
             'top_page_url',
             $specification['components']['schemas']['LoginResponse']['required']


### PR DESCRIPTION
## Summary
- return `role.code` from the login status API for authenticated users
- return `role: null` for guests so the response shape stays explicit
- update the OpenAPI schema and add regression tests for both API behavior and docs

## Why
- Issue #143 requires the login status response to include the role code
- the Swagger definition needed to match the implemented response

## Validation
- `./vendor/bin/phpunit tests/Feature/app/Http/Controllers/Auth/LoginStatusControllerTest.php`
- `./vendor/bin/phpunit --filter test_OpenAPI仕様のJSONを返す tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php`
- `./vendor/bin/phpunit tests/Feature/app/Http/Controllers/Auth`
- `./vendor/bin/phpunit tests/Feature/app/Http/Controllers/Docs`

Closes #143