### PR TITLE
[codex] Allow application index access for web and mobile users

### DIFF
--- a/routes/api/v2/application.php
+++ b/routes/api/v2/application.php
@@ -11,9 +11,15 @@ use App\Http\Controllers\Application\ApplicationAccountIndexController;
 use App\Http\Enums\Role\RoleEnum;
 
 Route::prefix('/applications')->group(function () {
-    Route::middleware(['auth:api', 'can:' . RoleEnum::ADMIN])->group(function () {
+    Route::middleware([
+        'auth:api',
+        'can:' . RoleEnum::ADMIN . ',' . RoleEnum::WEB_USER . ',' . RoleEnum::MOBILE_USER,
+    ])->group(function () {
         Route::get('/', ApplicationIndexController::class)
             ->name('applications.index');
+    });
+
+    Route::middleware(['auth:api', 'can:' . RoleEnum::ADMIN])->group(function () {
         Route::post('/', ApplicationCreateController::class)
             ->name('applications.create');
         Route::get('/{application}', ApplicationShowController::class)

--- a/tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php
@@ -89,15 +89,19 @@ class ApplicationIndexControllerTest extends PmappTestCase
         $response->assertStatus(401);
     }
 
-    public function test_WEB一般ユーザーはアプリケーションの一覧を取得できないこと(): void
+    public function test_WEB一般ユーザーはアプリケーションの一覧を取得できること(): void
     {
         $this->actingAs($this->webUser, 'api');
 
         $response = $this->getJson(route('applications.index'));
 
-        $response->assertStatus(404);
-        $response->assertExactJson([
-            'message' => 'Not Found',
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'id' => $this->markClassTrueApplication->id,
+            'name' => $this->markClassTrueApplication->name,
+            'account_class' => 0,
+            'notice_class' => 0,
+            'mark_class' => 1,
         ]);
     }
 }

--- a/tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php
+++ b/tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php
@@ -29,13 +29,13 @@ class AuthorizeRoleMiddlewareTest extends PmappTestCase
         ]);
     }
 
-    public function test_管理者以外はApplicationAPIにアクセスできないこと(): void
+    public function test_ApplicationAPIは全ロールアクセスできること(): void
     {
         $this->actingAs($this->webUser, 'api');
-        $this->getJson(route('applications.index'))->assertNotFound();
+        $this->getJson(route('applications.index'))->assertOk();
 
         $this->actingAs($this->mobileUser, 'api');
-        $this->getJson(route('applications.index'))->assertNotFound();
+        $this->getJson(route('applications.index'))->assertOk();
     }
 
     public function test_管理者以外はAccountAPIにアクセスできないこと(): void


### PR DESCRIPTION
## What changed
- allowed `WEB_USER` and `MOBILE_USER` to access `GET /api/v2/applications`
- updated `ApplicationIndexControllerTest` to expect a successful response for `WEB_USER`
- updated `AuthorizeRoleMiddlewareTest` to reflect that the application index API is now available to all roles

## Why
The application index route permission was expanded, but the related tests were still asserting the old `ADMIN`-only behavior. This PR aligns the route definition and test expectations.

## Impact
- `ADMIN`, `WEB_USER`, and `MOBILE_USER` can access the application list endpoint
- test coverage now matches the current authorization behavior

## Validation
- `docker compose exec -T app php artisan test tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php`
- `docker compose exec -T app php artisan test tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php`