### PR TITLE
Implement preregisted password create API

### DIFF
--- a/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateController.php
+++ b/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\PreregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PreregistedPassword\PreregistedPasswordCreateRequest;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Illuminate\Http\JsonResponse;
+
+class PreregistedPasswordCreateController extends Controller
+{
+    private const ALPHABET_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const ALPHABET_LOWER = 'abcdefghijklmnopqrstuvwxyz';
+
+    private const NUMBERS = '0123456789';
+
+    private const SYMBOLS = '!@#$%^&*';
+
+    public function __invoke(PreregistedPasswordCreateRequest $request): JsonResponse
+    {
+        $preregistedPasswordData = $request->input('preregisted_password');
+        $application = Application::query()->findOrFail($preregistedPasswordData['application_id']);
+
+        PreregistedPassword::create([
+            'password' => $this->generatePassword($application->pre_password_size, (bool) $application->mark_class),
+            'application_id' => $preregistedPasswordData['application_id'],
+            'account_id' => $preregistedPasswordData['account_id'],
+        ]);
+
+        return ApiResponseFormatter::ok();
+    }
+
+    private function generatePassword(int $length, bool $includeSymbols): string
+    {
+        $alphaNumericCharacters = self::ALPHABET_UPPER . self::ALPHABET_LOWER . self::NUMBERS;
+
+        if (! $includeSymbols) {
+            return $this->randomCharactersFrom($alphaNumericCharacters, $length);
+        }
+
+        $characters = $this->randomCharactersFrom(
+            $alphaNumericCharacters . self::SYMBOLS,
+            max(0, $length - 1)
+        ) . $this->randomCharactersFrom(self::SYMBOLS, 1);
+
+        return str_shuffle($characters);
+    }
+
+    private function randomCharactersFrom(string $characters, int $length): string
+    {
+        $generated = '';
+        $maxIndex = strlen($characters) - 1;
+
+        for ($index = 0; $index < $length; $index++) {
+            $generated .= $characters[random_int(0, $maxIndex)];
+        }
+
+        return $generated;
+    }
+}

--- a/app/Http/Requests/PreregistedPassword/PreregistedPasswordCreateRequest.php
+++ b/app/Http/Requests/PreregistedPassword/PreregistedPasswordCreateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\PreregistedPassword;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PreregistedPasswordCreateRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'preregisted_password.application_id' => [
+                'required',
+                'integer',
+                Rule::exists('applications', 'id')->whereNull('deleted_at'),
+            ],
+            'preregisted_password.account_id' => [
+                'required',
+                'integer',
+                Rule::exists('accounts', 'id')
+                    ->whereNull('deleted_at')
+                    ->where(function ($query) {
+                        $query->where('application_id', $this->input('preregisted_password.application_id'));
+                    }),
+            ],
+        ];
+    }
+}

--- a/app/Services/OpenApiSpecificationFactory.php
+++ b/app/Services/OpenApiSpecificationFactory.php
@@ -543,6 +543,10 @@ class OpenApiSpecificationFactory
                 'password.application_id',
                 'password.account_id',
             ]),
+            'PreregistedPasswordCreateValidationErrorResponse' => $this->validationErrorSchema([
+                'preregisted_password.application_id',
+                'preregisted_password.account_id',
+            ]),
             'PasswordLatestShowValidationErrorResponse' => $this->validationErrorSchema([
                 'application_id',
                 'account_id',
@@ -741,6 +745,7 @@ class OpenApiSpecificationFactory
             case 'AccountUpdateController':
             case 'AccountDeleteController':
             case 'PasswordCreateController':
+            case 'PreregistedPasswordCreateController':
             case 'PreregistedPasswordDeleteController':
             case 'UnregistedPasswordDeleteController':
                 return 'EmptySuccessResponse';
@@ -803,6 +808,8 @@ class OpenApiSpecificationFactory
                 return 'ApplicationUpdateValidationErrorResponse';
             case 'PasswordCreateController':
                 return 'PasswordCreateValidationErrorResponse';
+            case 'PreregistedPasswordCreateController':
+                return 'PreregistedPasswordCreateValidationErrorResponse';
             case 'PasswordLatestShowController':
                 return 'PasswordLatestShowValidationErrorResponse';
             case 'PasswordIndexController':

--- a/routes/api/v2/preregisted_password.php
+++ b/routes/api/v2/preregisted_password.php
@@ -4,6 +4,7 @@
 
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordDeleteController;
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordIndexController;
+use App\Http\Controllers\PreregistedPassword\PreregistedPasswordCreateController;
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordShowController;
 use App\Http\Enums\Role\RoleEnum;
 
@@ -12,6 +13,8 @@ Route::prefix('/preregisted-passwords')->group(function () {
         'auth:api',
         'can:' . RoleEnum::ADMIN . ',' . RoleEnum::WEB_USER . ',' . RoleEnum::MOBILE_USER,
     ])->group(function () {
+        Route::post('/', PreregistedPasswordCreateController::class)
+            ->name('preregisted-passwords.create');
         Route::get('/', PreregistedPasswordIndexController::class)
             ->name('preregisted-passwords.index');
         Route::get('/{preregistedPassword}', PreregistedPasswordShowController::class)

--- a/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
@@ -128,8 +128,20 @@ class OpenApiSpecificationShowControllerTest extends TestCase
             $specification['paths']['/api/v2/healthchecks']['post']['responses']['200']['content']['application/json']['schema']['$ref']
         );
         $this->assertSame(
+            '#/components/schemas/EmptySuccessResponse',
+            $specification['paths']['/api/v2/preregisted-passwords']['post']['responses']['200']['content']['application/json']['schema']['$ref']
+        );
+        $this->assertSame(
             '#/components/schemas/PreregistedPasswordResponse',
             $specification['paths']['/api/v2/preregisted-passwords/{preregistedPassword}']['get']['responses']['200']['content']['application/json']['schema']['$ref']
+        );
+        $this->assertSame(
+            '#/components/schemas/PreregistedPasswordCreateValidationErrorResponse',
+            $specification['paths']['/api/v2/preregisted-passwords']['post']['responses']['422']['content']['application/json']['schema']['$ref']
+        );
+        $this->assertSame(
+            '仮登録パスワード管理',
+            $specification['paths']['/api/v2/preregisted-passwords']['post']['tags'][0]
         );
         $this->assertSame(
             '#/components/schemas/UnregistedPasswordResponse',

--- a/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\PreregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use App\Models\PreregistedPassword;
+use Illuminate\Support\Facades\Crypt;
+use Tests\PmappTestCase;
+
+class PreregistedPasswordCreateControllerTest extends PmappTestCase
+{
+    private const SYMBOLS = '!@#$%^&*';
+
+    private Application $application;
+
+    private Account $account;
+
+    private Application $symbolApplication;
+
+    private Account $symbolAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = Application::factory()->create([
+            'mark_class' => false,
+            'pre_password_size' => 12,
+        ]);
+        $this->account = Account::factory()->create([
+            'application_id' => $this->application->id,
+        ]);
+
+        $this->symbolApplication = Application::factory()->create([
+            'mark_class' => true,
+            'pre_password_size' => 10,
+        ]);
+        $this->symbolAccount = Account::factory()->create([
+            'application_id' => $this->symbolApplication->id,
+        ]);
+    }
+
+    public function test_管理者が記号なし仮登録パスワードを正常に作成できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $createdPassword = PreregistedPassword::query()->latest('created_at')->first();
+
+        $this->assertNotNull($createdPassword);
+        $this->assertSame($this->application->id, $createdPassword->application_id);
+        $this->assertSame($this->account->id, $createdPassword->account_id);
+        $this->assertSame(12, strlen($createdPassword->password));
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]+$/', $createdPassword->password);
+
+        $encryptedPassword = $createdPassword->getRawOriginal('password');
+        $this->assertNotSame($createdPassword->password, $encryptedPassword);
+        $this->assertSame($createdPassword->password, Crypt::decryptString($encryptedPassword));
+    }
+
+    public function test_管理者が記号あり仮登録パスワードを正常に作成できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->symbolApplication->id,
+                'account_id' => $this->symbolAccount->id,
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $createdPassword = PreregistedPassword::query()
+            ->where('application_id', $this->symbolApplication->id)
+            ->where('account_id', $this->symbolAccount->id)
+            ->latest('created_at')
+            ->first();
+
+        $this->assertNotNull($createdPassword);
+        $this->assertSame(10, strlen($createdPassword->password));
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9!@#\\$%\\^&\\*]+$/', $createdPassword->password);
+        $this->assertTrue($this->containsSymbol($createdPassword->password));
+    }
+
+    public function test_WEB一般ユーザーが仮登録パスワードを正常に作成できること(): void
+    {
+        $this->actingAs($this->webUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('preregisted_passwords', [
+            'application_id' => $this->application->id,
+            'account_id' => $this->account->id,
+        ]);
+    }
+
+    public function test_モバイル一般ユーザーが仮登録パスワードを正常に作成できること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('preregisted_passwords', [
+            'application_id' => $this->application->id,
+            'account_id' => $this->account->id,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->application->id,
+                'account_id' => $this->account->id,
+            ],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_存在しないレコード指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => 999999,
+                'account_id' => 999999,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'preregisted_password.application_id',
+            'preregisted_password.account_id',
+        ]);
+    }
+
+    public function test_必須項目が未指定の場合は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'preregisted_password.application_id',
+            'preregisted_password.account_id',
+        ]);
+    }
+
+    public function test_型不正の場合は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => 'invalid-id',
+                'account_id' => 'invalid-id',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'preregisted_password.application_id',
+            'preregisted_password.account_id',
+        ]);
+    }
+
+    public function test_アプリケーションと紐付かないアカウント指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $otherApplication = Application::factory()->create();
+        $otherAccount = Account::factory()->create([
+            'application_id' => $otherApplication->id,
+        ]);
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->application->id,
+                'account_id' => $otherAccount->id,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['preregisted_password.account_id']);
+    }
+
+    private function containsSymbol(string $password): bool
+    {
+        return strpbrk($password, self::SYMBOLS) !== false;
+    }
+}


### PR DESCRIPTION
## What changed
- added `POST /api/v2/preregisted-passwords`
- implemented preregisted password creation request validation and controller logic
- generate preregisted passwords automatically from application settings
- include the new endpoint in OpenAPI expectations

## Why
- implements Issue #152
- follows the added specification comment: passwords are auto-generated, use `pre_password_size`, and include symbols only when `mark_class=true`

## Impact
- all allowed roles can create preregisted passwords without sending a password value
- generated passwords are persisted encrypted as before

## Validation
- `php artisan test tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php`
- `php artisan test tests/Feature/app/Http/Controllers/PreregistedPassword`
- `php artisan test tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php`