### PR TITLE
add preregisted password target api

### DIFF
--- a/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowController.php
+++ b/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\PreregistedPassword;
+
+use App\Helpers\ApiResponseFormatter;
+use App\Http\Controllers\Controller;
+use App\Models\Account;
+use App\Models\Application;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PreregistedPasswordTargetShowController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $applicationId = $request->query('application_id');
+
+        if (filter_var($applicationId, FILTER_VALIDATE_INT) === false) {
+            return ApiResponseFormatter::notfound();
+        }
+
+        $application = Application::query()->find($applicationId);
+
+        if (! $application) {
+            return ApiResponseFormatter::notfound();
+        }
+
+        $accountId = $request->query('account_id');
+
+        if (! $application->account_class) {
+            if (! is_null($accountId)) {
+                return ApiResponseFormatter::notfound();
+            }
+
+            return $this->response($application, null);
+        }
+
+        if (filter_var($accountId, FILTER_VALIDATE_INT) === false) {
+            return ApiResponseFormatter::notfound();
+        }
+
+        $account = Account::query()
+            ->where('application_id', $application->id)
+            ->find($accountId);
+
+        if (! $account) {
+            return ApiResponseFormatter::notfound();
+        }
+
+        return $this->response($application, $account);
+    }
+
+    private function response(Application $application, ?Account $account): JsonResponse
+    {
+        return ApiResponseFormatter::ok([
+            'application' => [
+                'id' => $application->id,
+                'name' => $application->name,
+            ],
+            'account' => $account ? [
+                'id' => $account->id,
+                'name' => $account->name,
+            ] : null,
+        ]);
+    }
+}

--- a/app/Services/OpenApiSpecificationFactory.php
+++ b/app/Services/OpenApiSpecificationFactory.php
@@ -481,6 +481,18 @@ class OpenApiSpecificationFactory
                 ],
                 'required' => ['uuid', 'password', 'application', 'account', 'created_at'],
             ],
+            'PreregistedPasswordTargetResponse' => [
+                'type' => 'object',
+                'properties' => [
+                    'application' => [
+                        '$ref' => '#/components/schemas/IdNameResource',
+                    ],
+                    'account' => [
+                        '$ref' => '#/components/schemas/NullableIdNameResource',
+                    ],
+                ],
+                'required' => ['application', 'account'],
+            ],
             'UnregistedPasswordIndexResponse' => $this->arraySchema('PreregistedPasswordIndexItem'),
             'UnregistedPasswordResponse' => [
                 '$ref' => '#/components/schemas/PreregistedPasswordResponse',
@@ -732,6 +744,8 @@ class OpenApiSpecificationFactory
                 return 'PreregistedPasswordIndexResponse';
             case 'PreregistedPasswordShowController':
                 return 'PreregistedPasswordResponse';
+            case 'PreregistedPasswordTargetShowController':
+                return 'PreregistedPasswordTargetResponse';
             case 'UnregistedPasswordIndexController':
                 return 'UnregistedPasswordIndexResponse';
             case 'UnregistedPasswordShowController':

--- a/routes/api/v2/preregisted_password.php
+++ b/routes/api/v2/preregisted_password.php
@@ -6,9 +6,18 @@ use App\Http\Controllers\PreregistedPassword\PreregistedPasswordDeleteController
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordIndexController;
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordCreateController;
 use App\Http\Controllers\PreregistedPassword\PreregistedPasswordShowController;
+use App\Http\Controllers\PreregistedPassword\PreregistedPasswordTargetShowController;
 use App\Http\Enums\Role\RoleEnum;
 
 Route::prefix('/preregisted-passwords')->group(function () {
+    Route::middleware([
+        'auth:api',
+        'can:' . RoleEnum::MOBILE_USER,
+    ])->group(function () {
+        Route::get('/target', PreregistedPasswordTargetShowController::class)
+            ->name('preregisted-passwords.target');
+    });
+
     Route::middleware([
         'auth:api',
         'can:' . RoleEnum::ADMIN . ',' . RoleEnum::WEB_USER . ',' . RoleEnum::MOBILE_USER,

--- a/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php
@@ -136,6 +136,10 @@ class OpenApiSpecificationShowControllerTest extends TestCase
             $specification['paths']['/api/v2/preregisted-passwords/{preregistedPassword}']['get']['responses']['200']['content']['application/json']['schema']['$ref']
         );
         $this->assertSame(
+            '#/components/schemas/PreregistedPasswordTargetResponse',
+            $specification['paths']['/api/v2/preregisted-passwords/target']['get']['responses']['200']['content']['application/json']['schema']['$ref']
+        );
+        $this->assertSame(
             '#/components/schemas/PreregistedPasswordCreateValidationErrorResponse',
             $specification['paths']['/api/v2/preregisted-passwords']['post']['responses']['422']['content']['application/json']['schema']['$ref']
         );
@@ -251,6 +255,10 @@ class OpenApiSpecificationShowControllerTest extends TestCase
         $this->assertSame(
             '仮登録パスワード管理',
             $specification['paths']['/api/v2/preregisted-passwords/{preregistedPassword}']['delete']['tags'][0]
+        );
+        $this->assertSame(
+            '仮登録パスワード管理',
+            $specification['paths']['/api/v2/preregisted-passwords/target']['get']['tags'][0]
         );
         $this->assertSame(
             '未登録パスワード管理',

--- a/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowControllerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers\PreregistedPassword;
+
+use App\Models\Account;
+use App\Models\Application;
+use Tests\PmappTestCase;
+
+class PreregistedPasswordTargetShowControllerTest extends PmappTestCase
+{
+    private Application $targetAccountClassTrueApplication;
+
+    private Account $account;
+
+    private Application $accountClassFalseApplication;
+
+    private Account $otherApplicationAccount;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->targetAccountClassTrueApplication = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $this->account = Account::factory()->create([
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'name' => '@test',
+        ]);
+
+        $this->accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+            'name' => 'アカウントなしアプリ',
+        ]);
+
+        $otherApplication = Application::factory()->create();
+        $this->otherApplicationAccount = Account::factory()->create([
+            'application_id' => $otherApplication->id,
+        ]);
+    }
+
+    public function test_モバイル一般ユーザーがaccount_class_trueの対象情報を取得できること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => $this->account->id,
+        ]));
+
+        $response->assertOk();
+        $response->assertJson([
+            'application' => [
+                'id' => $this->targetAccountClassTrueApplication->id,
+                'name' => $this->targetAccountClassTrueApplication->name,
+            ],
+            'account' => [
+                'id' => $this->account->id,
+                'name' => '@test',
+            ],
+        ]);
+    }
+
+    public function test_モバイル一般ユーザーがaccount_class_falseの対象情報を取得できること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->accountClassFalseApplication->id,
+        ]));
+
+        $response->assertOk();
+        $response->assertJson([
+            'application' => [
+                'id' => $this->accountClassFalseApplication->id,
+                'name' => 'アカウントなしアプリ',
+            ],
+            'account' => null,
+        ]);
+    }
+
+    public function test_未ログイン時は401になること(): void
+    {
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => $this->account->id,
+        ]));
+
+        $response->assertStatus(401);
+    }
+
+    public function test_管理者は利用できないこと(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => $this->account->id,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_WEB一般ユーザーは利用できないこと(): void
+    {
+        $this->actingAs($this->webUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => $this->account->id,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_application_id未指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target'));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_application_idが数値形式でない時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => 'invalid-id',
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しないapplication_id指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => 999999,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_account_class_falseでaccount_id指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $account = Account::factory()->create([
+            'application_id' => $this->accountClassFalseApplication->id,
+        ]);
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->accountClassFalseApplication->id,
+            'account_id' => $account->id,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_account_class_trueでaccount_id未指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_account_class_trueでaccount_idが数値形式でない時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => 'invalid-id',
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_account_class_trueで存在しないaccount_id指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => 999999,
+        ]));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_指定アプリケーションに紐づかないaccount_id指定時は404になること(): void
+    {
+        $this->actingAs($this->mobileUser, 'api');
+
+        $response = $this->getJson(route('preregisted-passwords.target', [
+            'application_id' => $this->targetAccountClassTrueApplication->id,
+            'account_id' => $this->otherApplicationAccount->id,
+        ]));
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php
+++ b/tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php
@@ -85,4 +85,28 @@ class AuthorizeRoleMiddlewareTest extends PmappTestCase
         $this->actingAs($this->mobileUser, 'api');
         $this->getJson(route('preregisted-passwords.index'))->assertOk();
     }
+
+    public function test_PreregistedPasswordTargetAPIはモバイル一般ユーザーのみアクセスできること(): void
+    {
+        $application = Application::factory()->create([
+            'account_class' => true,
+        ]);
+        $account = Account::factory()->create([
+            'application_id' => $application->id,
+        ]);
+
+        $parameters = [
+            'application_id' => $application->id,
+            'account_id' => $account->id,
+        ];
+
+        $this->actingAs($this->adminUser, 'api');
+        $this->getJson(route('preregisted-passwords.target', $parameters))->assertNotFound();
+
+        $this->actingAs($this->webUser, 'api');
+        $this->getJson(route('preregisted-passwords.target', $parameters))->assertNotFound();
+
+        $this->actingAs($this->mobileUser, 'api');
+        $this->getJson(route('preregisted-passwords.target', $parameters))->assertOk();
+    }
 }


### PR DESCRIPTION
## Summary
- add `/api/v2/preregisted-passwords/target` for mobile users to fetch preregisted password target application/account data
- return 404 for invalid, missing, or mismatched `application_id` / `account_id` combinations based on `account_class`
- document the new endpoint in OpenAPI and add feature tests for behavior and role access

## Why
- issue #155 requires an API that resolves the target application and account from query parameters before the temp password registration screen is shown

## Impact
- mobile clients can safely validate deep-link query parameters and display the target names before submitting preregisted password registration
- admin and web users cannot access this endpoint

## Validation
- `docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowControllerTest.php`
- `docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php`
- `docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php`
- `docker compose exec app vendor/bin/phpcs app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowController.php app/Services/OpenApiSpecificationFactory.php routes/api/v2/preregisted_password.php tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowControllerTest.php tests/Feature/app/Http/Middleware/AuthorizeRoleMiddlewareTest.php tests/Feature/app/Http/Controllers/Docs/OpenApiSpecificationShowControllerTest.php`
- `docker compose exec app vendor/bin/phpstan analyse app/Http/Controllers/PreregistedPassword/PreregistedPasswordTargetShowController.php app/Services/OpenApiSpecificationFactory.php`

Closes #155