### PR TITLE
[仮登録パスワード登録API] アカウント区分なしアプリケーションへのパスワード仮登録が考慮されていない

### DIFF
--- a/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateController.php
+++ b/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateController.php
@@ -27,7 +27,9 @@ class PreregistedPasswordCreateController extends Controller
         PreregistedPassword::create([
             'password' => $this->generatePassword($application->pre_password_size, (bool) $application->mark_class),
             'application_id' => $preregistedPasswordData['application_id'],
-            'account_id' => $preregistedPasswordData['account_id'],
+            'account_id' => $application->account_class
+                ? ($preregistedPasswordData['account_id'] ?? null)
+                : null,
         ]);
 
         return ApiResponseFormatter::ok();

--- a/app/Http/Requests/PreregistedPassword/PreregistedPasswordCreateRequest.php
+++ b/app/Http/Requests/PreregistedPassword/PreregistedPasswordCreateRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\PreregistedPassword;
 
+use App\Models\Application;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class PreregistedPasswordCreateRequest extends FormRequest
 {
@@ -21,7 +23,7 @@ class PreregistedPasswordCreateRequest extends FormRequest
                 Rule::exists('applications', 'id')->whereNull('deleted_at'),
             ],
             'preregisted_password.account_id' => [
-                'required',
+                'nullable',
                 'integer',
                 Rule::exists('accounts', 'id')
                     ->whereNull('deleted_at')
@@ -30,5 +32,36 @@ class PreregistedPasswordCreateRequest extends FormRequest
                     }),
             ],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $preregistedPassword = $this->input('preregisted_password', []);
+            $accountIdExists = is_array($preregistedPassword) && array_key_exists('account_id', $preregistedPassword);
+            $accountId = $accountIdExists ? $preregistedPassword['account_id'] : null;
+            $application = Application::query()->find(data_get($preregistedPassword, 'application_id'));
+            $accountIdField = 'preregisted_password.account_id';
+
+            $requiresAccountId = (! $application || $application->account_class) && ! $accountIdExists;
+            $prohibitsAccountId = $application
+                && ! $application->account_class
+                && $accountIdExists
+                && ! is_null($accountId);
+
+            if ($requiresAccountId) {
+                $validator->errors()->add(
+                    $accountIdField,
+                    'The preregisted_password.account_id field is required.'
+                );
+            }
+
+            if ($prohibitsAccountId) {
+                $validator->errors()->add(
+                    $accountIdField,
+                    'The preregisted_password.account_id field is prohibited.'
+                );
+            }
+        });
     }
 }

--- a/database/migrations/2026_05_03_120000_make_account_id_nullable_in_preregisted_passwords_table.php
+++ b/database/migrations/2026_05_03_120000_make_account_id_nullable_in_preregisted_passwords_table.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            Schema::create('preregisted_passwords_tmp', function (Blueprint $table) {
+                $table->uuid('uuid')->comment('UUID');
+                $table->string('password')->comment('パスワード');
+                $table->unsignedBigInteger('application_id')->comment('アプリケーションID');
+                $table->unsignedBigInteger('account_id')->nullable()->comment('アカウントID');
+                $table->timestamps();
+
+                $table->primary('uuid');
+                $table->index('application_id');
+                $table->index('account_id');
+            });
+
+            DB::statement('
+                INSERT INTO preregisted_passwords_tmp (uuid, password, application_id, account_id, created_at, updated_at)
+                SELECT uuid, password, application_id, account_id, created_at, updated_at
+                FROM preregisted_passwords
+            ');
+
+            Schema::drop('preregisted_passwords');
+            Schema::rename('preregisted_passwords_tmp', 'preregisted_passwords');
+            return;
+        }
+
+        DB::statement('ALTER TABLE preregisted_passwords ALTER COLUMN account_id DROP NOT NULL');
+    }
+
+    public function down(): void
+    {
+        DB::table('preregisted_passwords')->whereNull('account_id')->delete();
+
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            Schema::create('preregisted_passwords_tmp', function (Blueprint $table) {
+                $table->uuid('uuid')->comment('UUID');
+                $table->string('password')->comment('パスワード');
+                $table->unsignedBigInteger('application_id')->comment('アプリケーションID');
+                $table->unsignedBigInteger('account_id')->comment('アカウントID');
+                $table->timestamps();
+
+                $table->primary('uuid');
+                $table->index('application_id');
+                $table->index('account_id');
+            });
+
+            DB::statement('
+                INSERT INTO preregisted_passwords_tmp (uuid, password, application_id, account_id, created_at, updated_at)
+                SELECT uuid, password, application_id, account_id, created_at, updated_at
+                FROM preregisted_passwords
+            ');
+
+            Schema::drop('preregisted_passwords');
+            Schema::rename('preregisted_passwords_tmp', 'preregisted_passwords');
+            return;
+        }
+
+        DB::statement('ALTER TABLE preregisted_passwords ALTER COLUMN account_id SET NOT NULL');
+    }
+};

--- a/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php
@@ -20,11 +20,16 @@ class PreregistedPasswordCreateControllerTest extends PmappTestCase
 
     private Account $symbolAccount;
 
+    private Application $accountClassFalseApplication;
+
+    private Account $accountClassFalseApplicationAccount;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->application = Application::factory()->create([
+            'account_class' => true,
             'mark_class' => false,
             'pre_password_size' => 12,
         ]);
@@ -33,11 +38,21 @@ class PreregistedPasswordCreateControllerTest extends PmappTestCase
         ]);
 
         $this->symbolApplication = Application::factory()->create([
+            'account_class' => true,
             'mark_class' => true,
             'pre_password_size' => 10,
         ]);
         $this->symbolAccount = Account::factory()->create([
             'application_id' => $this->symbolApplication->id,
+        ]);
+
+        $this->accountClassFalseApplication = Application::factory()->create([
+            'account_class' => false,
+            'mark_class' => false,
+            'pre_password_size' => 8,
+        ]);
+        $this->accountClassFalseApplicationAccount = Account::factory()->create([
+            'application_id' => $this->accountClassFalseApplication->id,
         ]);
     }
 
@@ -204,6 +219,38 @@ class PreregistedPasswordCreateControllerTest extends PmappTestCase
             'preregisted_password' => [
                 'application_id' => $this->application->id,
                 'account_id' => $otherAccount->id,
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['preregisted_password.account_id']);
+    }
+
+    public function test_account_class_falseアプリではaccount_id未指定で作成できること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->accountClassFalseApplication->id,
+            ],
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('preregisted_passwords', [
+            'application_id' => $this->accountClassFalseApplication->id,
+            'account_id' => null,
+        ]);
+    }
+
+    public function test_account_class_falseアプリではaccount_id指定時は422になること(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->postJson(route('preregisted-passwords.create'), [
+            'preregisted_password' => [
+                'application_id' => $this->accountClassFalseApplication->id,
+                'account_id' => $this->accountClassFalseApplicationAccount->id,
             ],
         ]);
 


### PR DESCRIPTION
## What changed
- made preregisted password create validation depend on application.account_class
- allow account_id to be omitted for account_class=false applications and prohibit explicit account_id in that case
- added a migration to make preregisted_passwords.account_id nullable
- added regression tests for both account_class=true and account_class=false flows

## Why
Issue #157 was caused by the preregisted password create API always requiring account_id, even for applications without account classification.

## Impact
- mobile/web/admin users can create preregisted passwords for account_class=false applications without sending account_id
- invalid account_id usage for account_class=false applications is now rejected consistently

## Validation
- docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php
- docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/PreregistedPassword
- docker compose exec app vendor/bin/phpcs app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateController.php app/Http/Requests/PreregistedPassword/PreregistedPasswordCreateRequest.php tests/Feature/app/Http/Controllers/PreregistedPassword/PreregistedPasswordCreateControllerTest.php database/migrations/2026_05_03_120000_make_account_id_nullable_in_preregisted_passwords_table.php