### PR TITLE
[パスワード検索] 取得ボタン押下時に取得されるパスワードが暗号化されたままになっている

### DIFF
--- a/app/Http/Controllers/Password/PasswordLatestShowController.php
+++ b/app/Http/Controllers/Password/PasswordLatestShowController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Password\PasswordLatestShowRequest;
 use App\Models\Application;
 use App\Models\Password;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 
 class PasswordLatestShowController extends Controller
@@ -53,7 +54,7 @@ class PasswordLatestShowController extends Controller
         }
 
         return ApiResponseFormatter::ok([
-            'password' => $latestPassword->password,
+            'password' => Crypt::decryptString($latestPassword->getRawOriginal('password')),
         ]);
     }
 }

--- a/tests/Feature/app/Http/Controllers/Password/PasswordLatestShowControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Password/PasswordLatestShowControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Account;
 use App\Models\Application;
 use App\Models\Password;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Crypt;
 use Tests\PmappTestCase;
 
 class PasswordLatestShowControllerTest extends PmappTestCase
@@ -61,9 +62,10 @@ class PasswordLatestShowControllerTest extends PmappTestCase
             'account_id' => $this->account->id,
         ]));
 
+        $this->assertSame('latest-password', Crypt::decryptString($latestPassword->getRawOriginal('password')));
         $response->assertStatus(200);
         $response->assertJson([
-            'password' => $latestPassword->password,
+            'password' => 'latest-password',
         ]);
     }
 
@@ -92,9 +94,10 @@ class PasswordLatestShowControllerTest extends PmappTestCase
             'application_id' => $this->accountClassFalseApplication->id,
         ]));
 
+        $this->assertSame('latest-password', Crypt::decryptString($latestPassword->getRawOriginal('password')));
         $response->assertStatus(200);
         $response->assertJson([
-            'password' => $latestPassword->password,
+            'password' => 'latest-password',
         ]);
     }
 


### PR DESCRIPTION
## What changed
- decrypt the latest password response in `PasswordLatestShowController` using the stored raw encrypted value
- strengthen the feature test to verify the database value remains encrypted while the API returns the decrypted password

## Why
- the password search screen was copying the encrypted string to the clipboard when the latest password was fetched
- this change ensures the API returns the decrypted password expected by the client

## Root cause
- the latest password response path could surface the stored encrypted value instead of explicitly decrypting the persisted password before returning it

## Validation
- `docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/Password/PasswordLatestShowControllerTest.php`
- `docker compose exec app vendor/bin/phpunit tests/Feature/app/Http/Controllers/Password`
- `docker compose exec app composer phpcs` failed due to an existing unrelated EOF newline issue in `app/Http/Enums/Role/RoleEnum.php`

Closes #162
