### PR TITLE
[パスワード検索] アプリケーションを選択するプルダウンに削除済みのアプリケーションも表示されてしまう

### DIFF
--- a/app/Http/Controllers/Application/ApplicationIndexController.php
+++ b/app/Http/Controllers/Application/ApplicationIndexController.php
@@ -12,7 +12,9 @@ class ApplicationIndexController extends Controller
 {
     public function __invoke(): JsonResponse
     {
-        $applications = Application::orderBy('id')->get();
+        $applications = Application::whereNull('deleted_at')
+            ->orderBy('id')
+            ->get();
         $transformApplications = $this->transformApplications($applications);
         return ApiResponseFormatter::ok($transformApplications);
     }

--- a/tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php
@@ -2,14 +2,21 @@
 
 namespace Tests\Feature\app\Http\Controllers\Application;
 
+use App\Models\Application;
 use Tests\PmappTestCase;
 
 class ApplicationIndexControllerTest extends PmappTestCase
 {
+    private Application $deletedApplication;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->setUpApplication();
+        $this->deletedApplication = Application::factory()->create([
+            'name' => 'Deleted Application',
+        ]);
+        $this->deletedApplication->delete();
     }
 
     public function test_レスポンス形式の確認()
@@ -102,6 +109,19 @@ class ApplicationIndexControllerTest extends PmappTestCase
             'account_class' => 0,
             'notice_class' => 0,
             'mark_class' => 1,
+        ]);
+    }
+
+    public function test_削除済みアプリケーションはレスポンスに含まれないこと(): void
+    {
+        $this->actingAs($this->adminUser, 'api');
+
+        $response = $this->getJson(route('applications.index'));
+
+        $response->assertOk();
+        $response->assertJsonMissing([
+            'id' => $this->deletedApplication->id,
+            'name' => $this->deletedApplication->name,
         ]);
     }
 }


### PR DESCRIPTION
## What changed
- excluded soft-deleted applications from `GET /api/v2/applications`
- added a regression test to ensure deleted applications do not appear in the response

## Why
- Issue #169 reported that deleted applications were still shown in the application pull-down on the password search screen

## Impact
- password search consumers no longer receive deleted applications in the application list
- active applications continue to be returned in ID order as before

## Root cause
- the application index query did not make the soft-delete exclusion explicit for this endpoint

## Validation
- `docker compose exec -T app vendor/bin/phpunit tests/Feature/app/Http/Controllers/Application/ApplicationIndexControllerTest.php`
- `docker compose exec -T app vendor/bin/phpunit tests/Feature/app/Http/Controllers/Application`
- `docker compose exec -T app composer phpcs` failed due to an existing unrelated newline issue in `app/Http/Enums/Role/RoleEnum.php`

Closes #169
